### PR TITLE
Handle forbidden HTTP status

### DIFF
--- a/FanSabisu/Sources/MediaViewController.swift
+++ b/FanSabisu/Sources/MediaViewController.swift
@@ -131,6 +131,9 @@ class MediaViewController: GAITrackedViewController {
                 } catch MediaDownloaderError.tooManyRequests {
                     self.activityIndicatorView?.stopAnimating()
                     return self.presentMessage(title: String.localizedString(for: "ERROR_TITLE"), message: String.localizedString(for: "TOO_MANY_REQUESTS"), actionHandler: nil)
+                } catch MediaDownloaderError.forbidden {
+                    self.activityIndicatorView?.stopAnimating()
+                    return self.presentMessage(title: String.localizedString(for: "ERROR_TITLE"), message: String.localizedString(for: "FORBIDDEN"), actionHandler: nil)
                 } catch {
                     return self.presentMessage(title: String.localizedString(for: "ERROR_TITLE"), message: String.localizedString(for: "DOWNLOAD_VIDEO_ERROR"), actionHandler: nil)
                 }

--- a/FanSabisuKit/Assets/en.lproj/Localizable.strings
+++ b/FanSabisuKit/Assets/en.lproj/Localizable.strings
@@ -45,3 +45,4 @@
 "SAVE_FAILED" = "Couldn't save image";
 "CLEAR_CACHE" = "Clear cache";
 "CACHE_CLEARED" = "Cache cleared";
+"FORBIDDEN" = "You're not allowed to see this tweet. Try using a Twitter account following this user.";

--- a/FanSabisuKit/Sources/MediaDownloader.swift
+++ b/FanSabisuKit/Sources/MediaDownloader.swift
@@ -4,6 +4,7 @@ public enum MediaDownloaderError: Error {
     case invalidURL
     case requestFailed
     case tooManyRequests
+    case forbidden
 }
 
 public class MediaDownloader {
@@ -31,6 +32,9 @@ public class MediaDownloader {
                 let dataTask = self.session.dataTask(with: request) { (data, response, error) in
                     if (response as? HTTPURLResponse)?.statusCode == 429 {
                         return DispatchQueue.main.async { completionHandler(Result.failure(MediaDownloaderError.tooManyRequests)) }
+                    }
+                    if (response as? HTTPURLResponse)?.statusCode == 403 {
+                        return DispatchQueue.main.async { completionHandler(Result.failure(MediaDownloaderError.forbidden)) }
                     }
                     if (response as? HTTPURLResponse)?.statusCode != 200 {
                         return DispatchQueue.main.async { completionHandler(Result.failure(MediaDownloaderError.requestFailed)) }


### PR DESCRIPTION
If the tweet belongs to a user that has a protected account and the current logged in user (or default application user) doesn't have access to this tweet, Twitter REST API returns 403 HTTP status error. This PR handles that scenario.