### PR TITLE
Enable Keychain sharing between app and action extension

### DIFF
--- a/FanSabisu.xcodeproj/project.pbxproj
+++ b/FanSabisu.xcodeproj/project.pbxproj
@@ -649,6 +649,9 @@
 							com.apple.ApplicationGroups.iOS = {
 								enabled = 1;
 							};
+							com.apple.Keychain = {
+								enabled = 1;
+							};
 						};
 					};
 					3FF972631D992906002B9D1A = {
@@ -657,6 +660,9 @@
 						ProvisioningStyle = Manual;
 						SystemCapabilities = {
 							com.apple.ApplicationGroups.iOS = {
+								enabled = 1;
+							};
+							com.apple.Keychain = {
 								enabled = 1;
 							};
 						};

--- a/FanSabisu/Other sources/FanSabisu.entitlements
+++ b/FanSabisu/Other sources/FanSabisu.entitlements
@@ -6,5 +6,9 @@
 	<array>
 		<string>group.de.ruenzuo.fansabisu</string>
 	</array>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)de.ruenzuo.fansabisu</string>
+	</array>
 </dict>
 </plist>

--- a/FanSabisuActionUIExt/Other sources/FanSabisuActionUIExt.entitlements
+++ b/FanSabisuActionUIExt/Other sources/FanSabisuActionUIExt.entitlements
@@ -6,5 +6,9 @@
 	<array>
 		<string>group.de.ruenzuo.fansabisu</string>
 	</array>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)de.ruenzuo.fansabisu</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
App Groups capability was enabled between the application and the action extension to share the application access token shared through `NSUserDefaults`, but the Keychain Sharing capability was not, meaning the action extension never had access to the OAuth information for authorised users.

![tumblr_mrt6owz4ug1rj8nzio1_400](https://cloud.githubusercontent.com/assets/346590/20203081/422bd40a-a779-11e6-995e-f9bd745ef151.gif)
